### PR TITLE
Add Compatibility With True Darkness

### DIFF
--- a/src/main/java/dev/imb11/fog/api/CustomFogDefinition.java
+++ b/src/main/java/dev/imb11/fog/api/CustomFogDefinition.java
@@ -112,11 +112,12 @@ public final class CustomFogDefinition {
 
 		/**
 		 * @param day The color of the fog during the day - in #RRGGBB format.
-		 * @param night The color of the fog during the night - in #RRGGBB format.
+		 * @param nightFullMoon The color of the fog during the night - in #RRGGBB format.
+		 * @param nightNewMoon The color of the fog during the night during a new moon - in #RRGGBB format or null.
 		 * @return This builder.
 		 */
-		public Builder colors(String day, String night) {
-			this.colors = new FogColors(day, night);
+		public Builder colors(String day, String nightFullMoon, String nightNewMoon) {
+			this.colors = new FogColors(day, nightFullMoon, nightNewMoon);
 			return this;
 		}
 

--- a/src/main/java/dev/imb11/fog/api/NightColors.java
+++ b/src/main/java/dev/imb11/fog/api/NightColors.java
@@ -1,0 +1,12 @@
+package dev.imb11.fog.api;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import org.jetbrains.annotations.NotNull;
+
+public record NightColors(@NotNull String nightFullMoon, @NotNull String nightNewMoon) {
+	public static final Codec<NightColors> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+			Codec.STRING.fieldOf("nightFullMoon").forGetter(NightColors::nightFullMoon),
+			Codec.STRING.fieldOf("nightNewMoon").forGetter(NightColors::nightNewMoon)
+	).apply(instance, NightColors::new));
+}

--- a/src/main/java/dev/imb11/fog/client/util/math/EnvironmentCalculations.java
+++ b/src/main/java/dev/imb11/fog/client/util/math/EnvironmentCalculations.java
@@ -24,7 +24,7 @@ public class EnvironmentCalculations {
 
 	private static FogManager.@NotNull FogSettings applyCaveFog(float undergroundFactor, FogManager.FogSettings settings) {
 		FogColors belowGroundColors = FogColors.DEFAULT_CAVE;
-		Color belowColor = belowGroundColors.getNightColor();
+		Color belowColor = belowGroundColors.getNightFullMoonColor();
 
 		float fogColorR = MathHelper.lerp(undergroundFactor, belowColor.red / 255f, settings.fogRed()),
 				fogColorG = MathHelper.lerp(undergroundFactor, belowColor.green / 255f, settings.fogGreen()),

--- a/src/main/java/dev/imb11/fog/config/FogConfig.java
+++ b/src/main/java/dev/imb11/fog/config/FogConfig.java
@@ -48,6 +48,8 @@ public class FogConfig {
 	@SerialEntry
 	public boolean disableBiomeFogColour = false;
 	@SerialEntry
+	public boolean disableMoonPhaseColorTransition = false;
+	@SerialEntry
 	public boolean disableCloudWhitening = false;
 	@SerialEntry
 	public float initialFogStart = 0.1f;
@@ -146,6 +148,10 @@ public class FogConfig {
 				                        .option(HELPER.get(
 						                        "disable_biome_fog_colour", defaults.disableBiomeFogColour,
 						                        () -> config.disableBiomeFogColour, val -> config.disableBiomeFogColour = val
+				                        ))
+				                        .option(HELPER.get(
+						                        "disable_moon_phase_color_transition", defaults.disableMoonPhaseColorTransition,
+						                        () -> config.disableMoonPhaseColorTransition, val -> config.disableMoonPhaseColorTransition = val
 				                        ))
 				                        .option(Option.<Boolean>createBuilder().name(
 						                        HELPER.getText(EntryType.OPTION_NAME, "disable_cloud_whitening")).description(

--- a/src/main/java/dev/imb11/fog/loaders/fabric/datagen/VanillaFogDefinitionProvider.java
+++ b/src/main/java/dev/imb11/fog/loaders/fabric/datagen/VanillaFogDefinitionProvider.java
@@ -22,49 +22,49 @@ public class VanillaFogDefinitionProvider extends CustomFogDefinitionDataProvide
 	@Override
 	public void acceptBiomes(@NotNull BiConsumer<Identifier, CustomFogDefinition> provider) {
 		provider.accept(Identifier.tryParse("sparse_jungle"), CustomFogDefinition.Builder.create()
-                 .colors("#7EBAA2", "#1A2122").startMultiplier(0.75f).endMultiplier(1.0f).build());
+                 .colors("#7EBAA2", "#1A2122", null).startMultiplier(0.75f).endMultiplier(1.0f).build());
 
 		provider.accept(Identifier.tryParse("basalt_deltas"), CustomFogDefinition.Builder.create()
-				.colors("#36292B", "#36292B").startMultiplier(0.8f).endMultiplier(0.01f).build());
+				.colors("#36292B", "#36292B", null).startMultiplier(0.8f).endMultiplier(0.01f).build());
 
 		provider.accept(Identifier.tryParse("crimson_forest"), CustomFogDefinition.Builder.create()
-				.colors("#700f18", "#700f18").startMultiplier(0.8f).endMultiplier(0.01f).build());
+				.colors("#700f18", "#700f18", null).startMultiplier(0.8f).endMultiplier(0.01f).build());
 
 		provider.accept(Identifier.tryParse("warped_forest"), CustomFogDefinition.Builder.create()
-		        .colors("#0f4c4c", "#0f4c4c").startMultiplier(0.8f).endMultiplier(0.01f).build());
+		        .colors("#0f4c4c", "#0f4c4c", null).startMultiplier(0.8f).endMultiplier(0.01f).build());
 
 		provider.accept(Identifier.tryParse("soul_sand_valley"), CustomFogDefinition.Builder.create()
-		        .colors("#005157", "#005157").startMultiplier(1.0f).endMultiplier(0.01f).build());
+		        .colors("#005157", "#005157", null).startMultiplier(1.0f).endMultiplier(0.01f).build());
 
 		provider.accept(Identifier.tryParse("nether_wastes"), CustomFogDefinition.Builder.create()
-				.colors("#330808", "#330808").startMultiplier(1.0f).endMultiplier(0.01f).build());
+				.colors("#330808", "#330808", null).startMultiplier(1.0f).endMultiplier(0.01f).build());
 	}
 
 	@Override
 	public void acceptBiomeTags(@NotNull BiConsumer<TagKey<Biome>, CustomFogDefinition> provider) {
 		provider.accept(ConventionalBiomeTags.IS_JUNGLE, CustomFogDefinition.Builder.create()
-		        .colors("#5B9071", "#171E23").startMultiplier(0.15f).endMultiplier(0.35f).build());
+		        .colors("#5B9071", "#171E23", null).startMultiplier(0.15f).endMultiplier(0.35f).build());
 
 		provider.accept(ConventionalBiomeTags.IS_SWAMP, CustomFogDefinition.Builder.create()
-				.colors("#BDC8C2", "#5A6459").build());
+				.colors("#BDC8C2", "#5A6459", null).build());
 
 		provider.accept(ConventionalBiomeTags.IS_BADLANDS, CustomFogDefinition.Builder.create()
-				.colors("#BCA199", "#140c07").build());
+				.colors("#BCA199", "#140c07", null).build());
 
 		provider.accept(ConventionalBiomeTags.IS_DESERT, CustomFogDefinition.Builder.create()
-				.colors("#D1C8AB", "#827D6A").build());
+				.colors("#D1C8AB", "#827D6A", null).build());
 
 		provider.accept(ConventionalBiomeTags.IS_SNOWY, CustomFogDefinition.Builder.create()
-				.colors("#DFEBF4", "#687782").build());
+				.colors("#DFEBF4", "#687782", null).build());
 
 		provider.accept(ConventionalBiomeTags.IS_AQUATIC_ICY, CustomFogDefinition.Builder.create()
-				.colors("#BDDBE1", "#526C72").build());
+				.colors("#BDDBE1", "#526C72", null).build());
 
 		provider.accept(ConventionalBiomeTags.IS_BEACH, CustomFogDefinition.Builder.create()
-				.colors("#CBCABD", "#11110e").build());
+				.colors("#CBCABD", "#11110e", null).build());
 
 		provider.accept(ConventionalBiomeTags.IS_END, CustomFogDefinition.Builder.create()
-				.colors("#291d26", "#291d26")
+				.colors("#291d26", "#291d26", null)
 				.startMultiplier(0.5f).endMultiplier(0.5f).build());
 	}
 }

--- a/src/main/resources/assets/fog/lang/en_us.json
+++ b/src/main/resources/assets/fog/lang/en_us.json
@@ -12,6 +12,8 @@
   "fog.config.option.description.disable_underground_fog_multiplier": "Disables the underground fog multiplier, which makes the fog appear more dense and dark when the player is underground",
   "fog.config.option.disable_biome_fog_colour": "Disable Biome Fog Colour",
   "fog.config.option.description.disable_biome_fog_colour": "Disables the biome fog colour, which makes the fog colour change based on the biome the player is in",
+  "fog.config.option.disable_moon_phase_color_transition": "Disable Moon Phase Color Transition",
+  "fog.config.option.description.disable_moon_phase_color_transition": "Disables moon phase color transition, which makes the night fog colour change based on the moon phase if a transition is defined",
   "fog.config.option.disabled_dimensions": "Disabled Dimensions",
   "fog.config.option.description.disabled_dimensions": "Disables the fog modifications in the specified dimensions.",
   "fog.config.option.disable_cloud_whitening": "Disable Cloud Whitening",


### PR DESCRIPTION
https://github.com/IMB11/Fog/issues/48

This pull request adds an optional config option in the fog definition for defining "nightNewMoon" which represents the fog color at night during a new moon. If provided, the fog color at night will transition between "night" and "nightNewMoon" fog color depending on the moon phase.

Here is what it looks like if "/generated/assets/c/fog_definitions/tag/biome/is_desert.json" is changed to
```
{
  "colors": {
    "day": "#D1C8AB",
    "night": "#827D6A",
    "nightNewMoon": "#000000"
  },
  "end_multiplier": 1.0,
  "start_multiplier": 1.0
}
```
(all other configs untouched)
![fog-night-new-moon-test](https://github.com/user-attachments/assets/617da0be-18a0-4bb7-9230-27cb61deb73b)

Other biomes' fog colors are unchanged at night and are not affected by moon phase.